### PR TITLE
Avoid exposing findbugs to consumers runtime classpath

### DIFF
--- a/cpu-features-jni/build.gradle.kts
+++ b/cpu-features-jni/build.gradle.kts
@@ -3,7 +3,8 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.findBugs)
+    compileOnlyApi(libs.findBugs)
+    testImplementation(libs.findBugs)
     implementation(libs.jniGlueAnnotations)
     annotationProcessor(libs.jniGlueProcessor)
 }


### PR DESCRIPTION
Isn't needed at runtime in the general use case. Kept as `compileOnlyApi` instead of `compileOnly` so that the full classpath is available for the IDE (so no errors when viewing sources). Adding to `testImplementation` might not be needed but it doesn't hurt.